### PR TITLE
Fixes JSON parse error

### DIFF
--- a/Assets/Plugins/socket.io/SocketInitializer.cs
+++ b/Assets/Plugins/socket.io/SocketInitializer.cs
@@ -135,7 +135,10 @@ namespace socket.io {
                 var textIndex = www.text.IndexOf('{');
                 if (textIndex != -1) {
                     var json = www.text.Substring(textIndex);
-                    var answer = JsonUtility.FromJson<PollingUrlAnswer>(json);
+					if (!json.EndsWith("}")) {
+						json = json.Substring (0, json.LastIndexOf('}') + 1); 
+					}
+					var answer = JsonUtility.FromJson<PollingUrlAnswer>(json);
                     _urlQueries.Add("sid", answer.sid);
                 }
 


### PR DESCRIPTION
Fixes ArgumentException: JSON parse error: The document root must not follow by other values.


While the code checks for string starting with "{", it didnt check for ending with "}".